### PR TITLE
Update flutter_target_file_processor.dart

### DIFF
--- a/lib/processors/flutter/target/flutter_target_file_processor.dart
+++ b/lib/processors/flutter/target/flutter_target_file_processor.dart
@@ -46,7 +46,7 @@ class FlutterTargetFileProcessor extends QueueProcessor {
               '$destination/main_$flavorName.dart',
               ReplaceStringProcessor(
                 '[[FLAVOR_NAME]]',
-                flavorName.toUpperCase(),
+                flavorName.toLowerCase(),
                 config: config,
               ),
               config: config,


### PR DESCRIPTION
when generated flavors.dart file show this warning from dart:

```
The constant name 'SNOWBANK' isn't a lowerCamelCase identifier.
Try changing the name to follow the lowerCamelCase style.dartconstant_identifier_names

dart(constant_identifier_names)
```